### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/main/xg.py
+++ b/main/xg.py
@@ -5,8 +5,8 @@ from understat import Understat
 from .models import XgLookup
 import requests
 import json
-from fuzzywuzzy import fuzz
-from fuzzywuzzy import process
+from rapidfuzz import fuzz
+from rapidfuzz import process
 
 CURRENT_SEASON = 2019
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ coverage==5.0.3
 Django==2.2.5
 django-storages==1.8
 docutils==0.15.2
-fuzzywuzzy==0.18.0
 gunicorn==20.0.4
 idna==2.8
 importlib-metadata==1.1.0
@@ -40,6 +39,7 @@ pytest-cov==2.8.1
 pytest-mock==2.0.0
 python-dateutil==2.8.0
 pytz==2019.2
+rapidfuzz==0.3.0
 requests==2.22.0
 s3transfer==0.2.1
 selenium==3.141.0


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy